### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
     * 가장 최신 버전 사용
 * HUBBLE_API_KEY 발급
 
+<a href="https://glama.ai/mcp/servers/@ascentkorea/hubble_mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ascentkorea/hubble_mcp/badge" alt="Hubble Server MCP server" />
+</a>
+
 ## claude_desktop_config.json  파일 설정
 
 * 클로드 데스크탑 > 파일 > 설정(Ctrl + ,) > 개발자 > 설정 편집
@@ -77,4 +81,3 @@
   }
 }
 ```
-


### PR DESCRIPTION
This PR adds a badge for the [Hubble MCP Server](https://glama.ai/mcp/servers/@ascentkorea/hubble_mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ascentkorea/hubble_mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ascentkorea/hubble_mcp/badge" alt="Hubble Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.